### PR TITLE
Add Energy-Preserving Ambisonics Decoder (EPAD) and Mode-Matching Ambisonics Decoder (MAD)

### DIFF
--- a/examples/Loudspeaker_decoder.py
+++ b/examples/Loudspeaker_decoder.py
@@ -117,8 +117,10 @@ plots.decoder_performance(ls_setup, 'VBAP', retain_outside=True)
 plt.suptitle('VBAP with imaginary loudspeaker')
 plots.decoder_performance(ls_setup, 'VBIP', retain_outside=True)
 plt.suptitle('VBIP with imaginary loudspeaker')
+plots.decoder_performance(ls_setup, 'EPAD')
 plots.decoder_performance(ls_setup, 'ALLRAP')
 plots.decoder_performance(ls_setup, 'ALLRAP2')
+
 
 # %% Binauralize
 fs = 44100

--- a/spaudiopy/decoder.py
+++ b/spaudiopy/decoder.py
@@ -998,6 +998,10 @@ def epad(F_nm, hull, N_sph=None):
     ls_sig : (L, S) numpy.ndarray
         Loudspeaker L output signal S.
 
+    Notes
+    -----
+    L should be more than (N_sph+1)**2 .
+
     References
     ----------
     Zotter, F., Pomberger, H., & Noisternig, M. (2012). Energy-preserving
@@ -1012,7 +1016,7 @@ def epad(F_nm, hull, N_sph=None):
 
     L = hull.npoints
     if (L < (N_sph+1)**2):
-        raise ValueError(f'Not enough loudspeakers ({L}) for this N_sph!')
+        warn(f'Not enough loudspeakers ({L}) for this N_sph!')
 
     N_sph_in = int(np.sqrt(F_nm.shape[0]) - 1)
     assert(N_sph_in >= N_sph)  # for now
@@ -1025,7 +1029,7 @@ def epad(F_nm, hull, N_sph=None):
     S_new = np.eye(hull.npoints, (N_sph+1)**2)
     D = U @ S_new @ VH
     # Scale energy to unity
-    D = np.sqrt(4 * np.pi / L) * D
+    D = np.sqrt(S_new.shape[0] / S_new.shape[1]) * np.sqrt(4 * np.pi / L) * D
 
     # loudspeaker output signals
     ls_sig = D @ F_nm[:(N_sph+1)**2, :]

--- a/spaudiopy/decoder.py
+++ b/spaudiopy/decoder.py
@@ -572,7 +572,7 @@ def vbap(src, hull, valid_simplices=None, retain_outside=False, jobs_count=1):
             if hull.imaginary_ls_idx is None:
                 raise ValueError('No imaginary loudspeaker. Update hull!')
         else:
-            raise ValueError('Run hull.ambisonics_setup() first!')
+            raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
 
     if valid_simplices is None:
         valid_simplices = hull.valid_simplices
@@ -736,11 +736,11 @@ def allrap(src, hull, N_sph=None, jobs_count=1):
     if hull.ambisonics_hull:
         ambisonics_hull = hull.ambisonics_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if hull.kernel_hull:
         kernel_hull = hull.kernel_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if N_sph is None:
         N_sph = hull.characteristic_order
 
@@ -808,11 +808,11 @@ def allrap2(src, hull, N_sph=None, jobs_count=1):
     if hull.ambisonics_hull:
         ambisonics_hull = hull.ambisonics_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if hull.kernel_hull:
         kernel_hull = hull.kernel_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if N_sph is None:
         N_sph = hull.characteristic_order
 
@@ -851,8 +851,6 @@ def allrap2(src, hull, N_sph=None, jobs_count=1):
 
 def allrad(F_nm, hull, N_sph=None, jobs_count=1):
     """Loudspeaker signals of All-Round Ambisonic Decoder.
-    Zotter, F., & Frank, M. (2012). All-Round Ambisonic Panning and Decoding.
-    Journal of Audio Engineering Society, Sec. 6.
 
     Parameters
     ----------
@@ -869,15 +867,20 @@ def allrad(F_nm, hull, N_sph=None, jobs_count=1):
     ls_sig : (L, S) numpy.ndarray
         Loudspeaker L output signal S.
 
+    References
+    ----------
+    Zotter, F., & Frank, M. (2012). All-Round Ambisonic Panning and Decoding.
+    Journal of Audio Engineering Society, Sec. 6.
+
     """
     if hull.ambisonics_hull:
         ambisonics_hull = hull.ambisonics_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if hull.kernel_hull:
         kernel_hull = hull.kernel_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if N_sph is None:
         N_sph = hull.characteristic_order
 
@@ -915,8 +918,6 @@ def allrad(F_nm, hull, N_sph=None, jobs_count=1):
 
 def allrad2(F_nm, hull, N_sph=None, jobs_count=1):
     """Loudspeaker signals of All-Round Ambisonic Decoder 2.
-    Zotter, F., & Frank, M. (2018). Ambisonic decoding with panning-invariant
-    loudness on small layouts (AllRAD2). In 144th AES Convention.
 
     Parameters
     ----------
@@ -933,16 +934,21 @@ def allrad2(F_nm, hull, N_sph=None, jobs_count=1):
     ls_sig : (L, S) numpy.ndarray
         Loudspeaker L output signal S.
 
+    References
+    ----------
+    Zotter, F., & Frank, M. (2018). Ambisonic decoding with panning-invariant
+    loudness on small layouts (AllRAD2). In 144th AES Convention.
+
     """
     warn("ALLRAD2 currently rectifies the signal!!")
     if hull.ambisonics_hull:
         ambisonics_hull = hull.ambisonics_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if hull.kernel_hull:
         kernel_hull = hull.kernel_hull
     else:
-        raise ValueError('Run hull.ambisonics_setup() first!')
+        raise ValueError('Run LoudspeakerSetup.ambisonics_setup() first!')
     if N_sph is None:
         N_sph = hull.characteristic_order
 

--- a/spaudiopy/decoder.py
+++ b/spaudiopy/decoder.py
@@ -1027,10 +1027,11 @@ def epad(F_nm, hull, N_sph=None):
     Y_ls = sph.sh_matrix(N_sph, ls_azi, ls_colat, SH_type='real')
     U, S, VH = np.linalg.svd(Y_ls)
     # Set singular values to identity and truncate
-    S_new = np.eye(hull.npoints, (N_sph+1)**2)
+    S_new = np.eye(L, (N_sph+1)**2)
     D = U @ S_new @ VH
-    # Scale energy to unity
-    D = np.sqrt(S_new.shape[0] / S_new.shape[1]) * np.sqrt(4 * np.pi / L) * D
+    # Scale to unity
+    D *= np.sqrt(4 * np.pi / L)  # Amplitude to unity
+    D *= np.sqrt(L / (N_sph+1)**2)  # Energy to unity
 
     # loudspeaker output signals
     ls_sig = D @ F_nm[:(N_sph+1)**2, :]

--- a/spaudiopy/decoder.py
+++ b/spaudiopy/decoder.py
@@ -1016,7 +1016,8 @@ def epad(F_nm, hull, N_sph=None):
 
     L = hull.npoints
     if (L < (N_sph+1)**2):
-        warn(f'Not enough loudspeakers ({L}) for this N_sph!')
+        warn('EPAD needs more loudspeakers for this N_sph!'
+             f' ({L} < {(N_sph+1)**2})')
 
     N_sph_in = int(np.sqrt(F_nm.shape[0]) - 1)
     assert(N_sph_in >= N_sph)  # for now

--- a/spaudiopy/decoder.py
+++ b/spaudiopy/decoder.py
@@ -152,9 +152,12 @@ class LoudspeakerSetup:
 
     def get_characteristic_order(self):
         """Characteristic Ambisonics order."""
-        N_e = characteristic_ambisonic_order(self)
-        if N_e < 1:
-            raise ValueError
+        if self.characteristic_order is None:
+            N_e = characteristic_ambisonic_order(self)
+            if N_e < 1:
+                raise ValueError
+        else:
+            N_e = self.characteristic_order
         return N_e
 
     def ambisonics_setup(self, N_kernel=50, update_hull=False,
@@ -979,7 +982,7 @@ def allrad2(F_nm, hull, N_sph=None, jobs_count=1):
     return ls_sig
 
 
-def epad(F_nm, hull, N_sph=None, jobs_count=1):
+def epad(F_nm, hull, N_sph=None, tapering=True):
     """Loudspeaker signals of Energy-Preserving Ambisonic Decoder.
 
     Parameters
@@ -989,8 +992,6 @@ def epad(F_nm, hull, N_sph=None, jobs_count=1):
     hull : LoudspeakerSetup
     N_sph : int
         Decoding order.
-    jobs_count : int or None, optional
-        Number of parallel jobs, 'None' employs 'cpu_count'.
 
     Returns
     -------
@@ -999,7 +1000,7 @@ def epad(F_nm, hull, N_sph=None, jobs_count=1):
 
     References
     ----------
-    Zotter, F., Pomberger, H., & Noisternig, M. (2012). Energy-preserving 
+    Zotter, F., Pomberger, H., & Noisternig, M. (2012). Energy-preserving
     ambisonic decoding. Acta Acustica United with Acustica, 98(1), 37–47.
 
     """
@@ -1009,8 +1010,8 @@ def epad(F_nm, hull, N_sph=None, jobs_count=1):
         else:
             N_sph = hull.get_characteristic_order()
 
-    if (hull.points < (N_sph+1)**2):
-        raise ValueError('Not enough loudspeakers!')
+    if (hull.npoints < (N_sph+1)**2):
+        raise ValueError(f'Not enough loudspeakers ({hull.npoints})!')
 
     N_sph_in = int(np.sqrt(F_nm.shape[0]) - 1)
     assert(N_sph_in >= N_sph)  # for now
@@ -1022,12 +1023,15 @@ def epad(F_nm, hull, N_sph=None, jobs_count=1):
     # Set singular values to identity and truncate
     S_new = np.eye(hull.npoints, (N_sph+1)**2)
     D = U @ S_new @ VH
+    #D = 4 * np.pi / hull.npoints * D
 
-    # SH tapering coefficients
-    a_n = sph.max_rE_weights(N_sph)
-    a_n = sph.repeat_order_coeffs(a_n)
-    # apply tapering to decoder matrix
-    D = D @ np.diag(a_n)
+    if tapering:
+        # SH tapering coefficients
+        a_n = sph.max_rE_weights(N_sph)
+        a_n = sph.repeat_order_coeffs(a_n)
+        # apply tapering to decoder matrix
+        D = D @ np.diag(a_n)
+
     # loudspeaker output signals
     ls_sig = D @ F_nm[:(N_sph+1)**2, :]
     return ls_sig

--- a/spaudiopy/decoder.py
+++ b/spaudiopy/decoder.py
@@ -982,7 +982,7 @@ def allrad2(F_nm, hull, N_sph=None, jobs_count=1):
     return ls_sig
 
 
-def epad(F_nm, hull, N_sph=None, tapering=True):
+def epad(F_nm, hull, N_sph=None):
     """Loudspeaker signals of Energy-Preserving Ambisonic Decoder.
 
     Parameters
@@ -1010,8 +1010,9 @@ def epad(F_nm, hull, N_sph=None, tapering=True):
         else:
             N_sph = hull.get_characteristic_order()
 
-    if (hull.npoints < (N_sph+1)**2):
-        raise ValueError(f'Not enough loudspeakers ({hull.npoints})!')
+    L = hull.npoints
+    if (L < (N_sph+1)**2):
+        raise ValueError(f'Not enough loudspeakers ({L}) for this N_sph!')
 
     N_sph_in = int(np.sqrt(F_nm.shape[0]) - 1)
     assert(N_sph_in >= N_sph)  # for now
@@ -1023,14 +1024,8 @@ def epad(F_nm, hull, N_sph=None, tapering=True):
     # Set singular values to identity and truncate
     S_new = np.eye(hull.npoints, (N_sph+1)**2)
     D = U @ S_new @ VH
-    #D = 4 * np.pi / hull.npoints * D
-
-    if tapering:
-        # SH tapering coefficients
-        a_n = sph.max_rE_weights(N_sph)
-        a_n = sph.repeat_order_coeffs(a_n)
-        # apply tapering to decoder matrix
-        D = D @ np.diag(a_n)
+    # Scale energy to unity
+    D = np.sqrt(4 * np.pi / L) * D
 
     # loudspeaker output signals
     ls_sig = D @ F_nm[:(N_sph+1)**2, :]


### PR DESCRIPTION
Tested with


```
import numpy as np
import matplotlib.pyplot as plt

import spaudiopy as spa

plt.close('all')
ls_layout = spa.IO.load_layout('../data/ls_layouts/MCC_subset_C.json')

ls_layout.show()


spa.plots.decoder_performance(ls_layout, 'VBAP')

spa.plots.decoder_performance(ls_layout, 'ALLRAD')
spa.plots.decoder_performance(ls_layout, 'ALLRAD', N_sph=3)

spa.plots.decoder_performance(ls_layout, 'ALLRAD2')
spa.plots.decoder_performance(ls_layout, 'ALLRAD2', N_sph=3)

spa.plots.decoder_performance(ls_layout, 'EPAD')
spa.plots.decoder_performance(ls_layout, 'EPAD', N_sph=3)


plt.show()
```
